### PR TITLE
Add Vite env templates, root build scripts, and README updates for multi-UI builds/deployment

### DIFF
--- a/Admin/.env.example
+++ b/Admin/.env.example
@@ -1,0 +1,2 @@
+# URL of the PolantyHotels API used by the admin UI.
+VITE_API_BASE_URL=http://localhost:3000

--- a/FrontEnd/my-react-app/.env.example
+++ b/FrontEnd/my-react-app/.env.example
@@ -1,0 +1,5 @@
+# URL of the PolantyHotels API used by the customer UI.
+VITE_API_BASE_URL=http://localhost:3000
+
+# Public Mapbox token used to render hotel maps.
+VITE_MAPBOX_TOKEN=your_mapbox_token_here

--- a/README.md
+++ b/README.md
@@ -789,6 +789,26 @@ PolantyHotels/
 
 ### Development Scripts
 
+**Both UIs (from the repository root):**
+```bash
+npm run build:user      # Build the customer UI into FrontEnd/my-react-app/dist
+npm run build:admin     # Build the admin UI into Admin/dist
+npm run build:all       # Build both UIs
+```
+
+Each UI is an independent Vite application and can be deployed separately. Copy
+its environment example before building, then replace the development values
+with the production API URL and Mapbox token as appropriate:
+
+```bash
+cp FrontEnd/my-react-app/.env.example FrontEnd/my-react-app/.env.production
+cp Admin/.env.example Admin/.env.production
+npm run build:all
+```
+
+Vite loads `.env.production` during `npm run build`. Do not commit that file;
+only the safe `.env.example` templates belong in source control.
+
 **Backend:**
 ```bash
 npm start              # Start server with nodemon (auto-reload)
@@ -920,17 +940,26 @@ Response:
 
 ### Deployment Steps
 
-1. **Build frontend**
+1. **Build the customer and admin frontends**
    ```bash
-   cd FrontEnd/my-react-app
-   npm run build  # Creates dist/ folder
+   # Run from the repository root
+   npm run build:all
    ```
 
-2. **Deploy to CloudFront/S3**
+   This creates two independent deployment artifacts:
+   - `FrontEnd/my-react-app/dist/` for the customer website
+   - `Admin/dist/` for the admin dashboard
+
+2. **Deploy each UI to its own CloudFront/S3 destination**
    ```bash
-   aws s3 sync dist/ s3://your-bucket-name/
-   aws cloudfront create-invalidation --distribution-id YOUR_DIST_ID --paths "/*"
+   aws s3 sync FrontEnd/my-react-app/dist/ s3://your-customer-ui-bucket/ --delete
+   aws s3 sync Admin/dist/ s3://your-admin-ui-bucket/ --delete
    ```
+
+   Configure each static host to serve `index.html` for unknown paths so that
+   React Router routes work when opened directly. A typical domain layout is
+   `www.example.com` for customers, `admin.example.com` for administrators, and
+   `api.example.com` for the backend. Allow both UI origins in backend CORS.
 
 3. **Deploy backend to Elastic Beanstalk**
    ```bash

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "polanty-hotels",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build:user": "npm run build --prefix FrontEnd/my-react-app",
+    "build:admin": "npm run build --prefix Admin",
+    "build:all": "npm run build:user && npm run build:admin"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide environment variable templates for both the customer and admin Vite apps so developers have safe examples to copy for local and production builds. 
- Centralize and simplify building both frontends from the repository root with lightweight npm scripts. 
- Clarify development and deployment steps so the two independent Uite artifacts can be built and deployed separately. 

### Description
- Added `Admin/.env.example` and `FrontEnd/my-react-app/.env.example` containing `VITE_API_BASE_URL` and a `VITE_MAPBOX_TOKEN` placeholder. 
- Added a repository root `package.json` with `build:user`, `build:admin`, and `build:all` scripts to run Vite builds for each UI. 
- Updated `README.md` to document new build scripts, copying `.env.example` to `.env.production` before building, and revised deployment steps to build both UIs and sync `FrontEnd/my-react-app/dist/` and `Admin/dist/` to separate S3/CloudFront locations. 
- Documented not to commit `.env.production`, instructions for serving `index.html` for SPA routing, and recommended domain layout and CORS considerations. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ca362ef3c8324b4d53be062a51360)